### PR TITLE
Add IODispatcher's Submit() integration test

### DIFF
--- a/src/bio/ubio.rs
+++ b/src/bio/ubio.rs
@@ -3,11 +3,13 @@ use std::sync::mpsc::Sender;
 use crate::device::base::ublock_device::UBlockDevice;
 use crate::include::i_array_device::IArrayDevice;
 
+// TODO: Callback needs to be generic (refer to Callback.cpp)
+type Callback = Box<dyn FnMut(&Vec<u8>)->()>;
+
 pub struct Ubio {
     pub dir: UbioDir,
     pub dataBuffer: Option<Vec<u8>>,
-    pub callback: Option<fn(Sender<Vec<u8>> /* channel */, &Vec<u8> /* data reference */)->()>,
-    pub callback_tx: Option<Sender<Vec<u8>>>,
+    pub callback: Callback,
     pub lba: u64,
     pub uBlock: Option<Box<dyn UBlockDevice>>,
     pub arrayDev: Option<Box<dyn IArrayDevice>>,
@@ -16,12 +18,11 @@ pub struct Ubio {
 }
 
 impl Ubio {
-    pub fn new(dir: UbioDir, lba: u64, dataBuffer: Vec<u8>) -> Ubio {
+    pub fn new(dir: UbioDir, lba: u64, dataBuffer: Vec<u8>, callback: Callback) -> Ubio {
         Ubio {
             dir: dir,
             dataBuffer: Some(dataBuffer),
-            callback: None,
-            callback_tx: None,
+            callback: callback,
             lba: lba,
             uBlock: None,
             arrayDev: None,

--- a/src/bio/ubio.rs
+++ b/src/bio/ubio.rs
@@ -1,11 +1,13 @@
+use std::fmt::{Debug, Formatter};
+use std::sync::mpsc::Sender;
 use crate::device::base::ublock_device::UBlockDevice;
 use crate::include::i_array_device::IArrayDevice;
 
-#[derive(Debug)]
 pub struct Ubio {
     pub dir: UbioDir,
     pub dataBuffer: Option<Vec<u8>>,
-    pub callback: Option<fn()->()>,
+    pub callback: Option<fn(Sender<Vec<u8>> /* channel */, &Vec<u8> /* data reference */)->()>,
+    pub callback_tx: Option<Sender<Vec<u8>>>,
     pub lba: u64,
     pub uBlock: Option<Box<dyn UBlockDevice>>,
     pub arrayDev: Option<Box<dyn IArrayDevice>>,
@@ -19,12 +21,23 @@ impl Ubio {
             dir: dir,
             dataBuffer: Some(dataBuffer),
             callback: None,
+            callback_tx: None,
             lba: lba,
             uBlock: None,
             arrayDev: None,
             arrayId: 0,
             arrayName: "".to_string()
         }
+    }
+}
+
+impl Debug for Ubio {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Ubio")
+            .field("dir", &self.dir)
+            .field("lba", &self.lba)
+            .field("arrayName", &self.arrayName)
+            .finish()
     }
 }
 

--- a/src/device/ufile/ufile_ssd.rs
+++ b/src/device/ufile/ufile_ssd.rs
@@ -32,7 +32,12 @@ impl UBlockDevice for UfileSsd {
         match bio.callback {
             None => {}
             Some(f) => {
-                f();
+                if let Some(tx) = &bio.callback_tx {
+                    let data = bio.dataBuffer.as_ref().unwrap();
+                    f(tx.clone(), data);
+                } else {
+                    warn!("Did you forget to put a sender channel for your read?");
+                }
             }
         }
         0
@@ -79,7 +84,7 @@ impl UBlockDevice for UfileSsd {
             file: None,
         };
         if self.file.is_some() {
-            new_ufile_ssd.Open();
+            new_ufile_ssd.Open(); // TODO: 이런 방식의 Clone은 문제가 있을 지도. 동일 file을 각각 열어서 쓰면 consistency 문제가 있을 수 있으니.
         }
         Box::new(new_ufile_ssd)
     }

--- a/src/io_scheduler/io_dispatcher.rs
+++ b/src/io_scheduler/io_dispatcher.rs
@@ -55,23 +55,52 @@ pub fn RegisterRecoveryEventFactory(_recoveryEventFactory: IoRecoveryEventFactor
 }
 
 #[cfg(test)]
+#[allow(non_snake_case)]
 mod tests {
+    use std::sync::mpsc::channel;
+    use log::{debug, info};
     use crate::bio::ubio::{Ubio, UbioDir};
     use crate::device::base::ublock_device::UBlockDevice;
     use crate::device::ufile::ufile_ssd::UfileSsd;
     use crate::io_scheduler::io_dispatcher::IODispatcherSingleton;
 
+    fn init() {
+        let _ = env_logger::builder().is_test(true).try_init();
+    }
+
     #[test]
     fn test_submit_io_to_ufile_ssd() {
+        init();
+
+        // Given: a device written with a specific pattern
         let mut ublock_device = UfileSsd::new("/tmp/dev1".into(), 1024*1024);
         ublock_device.Open();
+        let mut ublock_device_cloned = ublock_device.clone_box(); // TODO: clone vs. arc<mutex> 고민해볼 것.
 
         let PATTERN = b"CerTAinUnIquePATteRn";
-        let mut ubio = Ubio::new(UbioDir::Write, 0, PATTERN.to_vec());
-        ubio.uBlock = Some(ublock_device.boxed());
+        let mut write_ubio = Ubio::new(UbioDir::Write, 0, PATTERN.to_vec());
+        write_ubio.uBlock = Some(ublock_device.boxed()); // TODO: move to constructor param
 
-        IODispatcherSingleton.lock().unwrap().Submit(ubio, false, false);
+        IODispatcherSingleton.lock().unwrap().Submit(write_ubio, false, false);
 
-        //ublock_device.Close();
+        // When: we read a block where the pattern was written to
+        let mut dataBuffer = vec![0; PATTERN.len()];
+        let mut read_ubio = Ubio::new(UbioDir::Read, 0, dataBuffer);
+        let (tx, rx) = channel::<Vec<u8>>();
+        read_ubio.uBlock = Some(ublock_device_cloned);
+        read_ubio.callback_tx = Some(tx);
+        read_ubio.callback = Some(move |tx, data| {
+            // TODO: callback 이라기 보다는 completion handler에 가까운데, 일단 POC로 동작 검증. 사용성에 대해서는 추가 고민 필요할듯.
+            debug!("read callback is invoked");
+            tx.send(data.to_vec()); // TODO: 복사가 없이 sender에게 보낼 수 있으면 좋을 듯.
+        });
+        IODispatcherSingleton.lock().unwrap().Submit(read_ubio, false, false);
+
+        // Then: we should see the same pattern
+        let actual = rx.recv();
+        assert!(actual.is_ok());
+        let actual = actual.unwrap();
+
+        assert_eq!(PATTERN.to_vec(), actual);
     }
 }


### PR DESCRIPTION
IO dispatcher와 ufile_ssd의 통합 테스트 예제입니다. main code의 IO path 구현은 아직이고, test code 예제 작성하면서 어떤 방식이 나을지 시도해보는 중입니다. 일단은, 1) synchronous read/write 이고, 2) ubio callback은 read completion 만 일단 시도해 보았고, 3) buffer에 읽어온 데이터는 channel을 통해서, caller에게 건네주는 방식이고, 4) ubio 의 pub member를 직접 access 하는 방식, 5) uBlock의 clone은 reference만 복사하는 것이 아니라 객체를 한번 더 생성하는 방식입니다. 
각각에 대해 개선의 여지가 있는데, POS io path 쪽 코드 좀 더 공부해보면서, 좀 더 탐구가 필요할 것 같습니다; 일단 early review를 위해 PR 올립니다