### PR TITLE
Mbrmanager _IterateReadFromDevices Integration test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ static_assertions = "1.1.0"
 toml = "0.5.9"
 serde = { version = "1.0", features = ["derive"] }
 strum_macros = "0.24.3"
+crossbeam = "0.8.2"
 
 [build-dependencies]
 bindgen = "0.60.1"

--- a/src/bio/ubio.rs
+++ b/src/bio/ubio.rs
@@ -4,12 +4,12 @@ use crate::device::base::ublock_device::UBlockDevice;
 use crate::include::i_array_device::IArrayDevice;
 
 // TODO: Callback needs to be generic (refer to Callback.cpp)
-type Callback = Box<dyn FnMut(&Vec<u8>)->()>;
+pub type CallbackClosure = Box<dyn FnMut(&Vec<u8>)->()>;
 
 pub struct Ubio {
     pub dir: UbioDir,
     pub dataBuffer: Option<Vec<u8>>,
-    pub callback: Callback,
+    pub callback: CallbackClosure,
     pub lba: u64,
     pub uBlock: Option<Box<dyn UBlockDevice>>,
     pub arrayDev: Option<Box<dyn IArrayDevice>>,
@@ -18,7 +18,7 @@ pub struct Ubio {
 }
 
 impl Ubio {
-    pub fn new(dir: UbioDir, lba: u64, dataBuffer: Vec<u8>, callback: Callback) -> Ubio {
+    pub fn new(dir: UbioDir, lba: u64, dataBuffer: Vec<u8>, callback: CallbackClosure) -> Ubio {
         Ubio {
             dir: dir,
             dataBuffer: Some(dataBuffer),
@@ -42,7 +42,7 @@ impl Debug for Ubio {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum UbioDir {
     Read,
     Write,

--- a/src/include/meta_const.rs
+++ b/src/include/meta_const.rs
@@ -1,0 +1,2 @@
+pub const STRIPE_CHUNKS_SIZE: u64 = 256;
+pub const CHUNK_SIZE: u64 = STRIPE_CHUNKS_SIZE * 1024;

--- a/src/include/mod.rs
+++ b/src/include/mod.rs
@@ -6,3 +6,4 @@ pub mod io_error_type;
 pub mod i_array_device;
 pub mod backend_event;
 pub mod raid_type;
+pub mod meta_const;

--- a/src/mbr/mbr_manager.rs
+++ b/src/mbr/mbr_manager.rs
@@ -1,6 +1,22 @@
 use crate::mbr::mbr_info::{ArrayBootRecord, masterBootRecord};
+use std::any::Any;
+use std::rc::Rc;
+use std::sync::Mutex;
+use anyhow::Result;
+use crossbeam::sync::Parker;
+use log::warn;
+
 use crate::array::meta::array_meta::ArrayMeta;
+use crate::bio::ubio::{CallbackClosure, Ubio, UbioDir};
 use crate::include::pos_event_id::PosEventId;
+use crate::bio::ubio::{Ubio, UbioDir};
+use crate::device::base::ublock_device::UBlockDevice;
+use crate::event_scheduler::callback::Callback;
+use crate::include::meta_const::CHUNK_SIZE;
+use crate::io_scheduler::io_dispatcher::IODispatcherSingleton;
+
+const MBR_CHUNKS : i32 = 1;
+const MBR_ADDRESS: u64 = 0;
 
 pub struct MbrManager;
 
@@ -22,4 +38,136 @@ impl MbrManager {
     pub fn UpdateDeviceIndexMap(&self, arrayName: &String) -> Result<(), PosEventId> { todo!(); }
     pub fn FindArrayWithDeviceSN(&self, devSN: String) -> String { String::new() }
     pub fn Serialize(&self) -> String { todo!(); }
+
+    fn _IterateReadFromDevices(&self, dev: Box<dyn UBlockDevice>, ctx: &mut Vec<Vec<u8>>/*Box<dyn Any>*/) {
+        // "ctx" is likely to be byte buffer, so can be refactored accordingly later.
+        let mut mems = ctx;
+        let mem = [0 as u8; CHUNK_SIZE as usize * MBR_CHUNKS as usize].to_vec();
+        let diskIoCtxt = DiskIoContext::new(UbioDir::Read, mem);
+        let result_buffer = self._DiskIo(dev, diskIoCtxt)
+            .expect("Failed to read MBR from a device"); // TODO: device id API 생기면 메시지에 추가
+        if !self._VerifyParity(&result_buffer) {
+            warn!("Failed to verify MBR parity");
+            return;
+        }
+        if !self._VerifySystemUuid(&result_buffer) {
+            warn!("Failed to verify System UUID from MBR");
+            return;
+        }
+        mems.push(result_buffer);
+    }
+
+    fn _DiskIo(&self, dev: Box<dyn UBlockDevice>, ctx: DiskIoContext) -> Option<Vec<u8>> {
+        let result_buffer = Rc::new(Mutex::new(Vec::new()));
+        let io_done_parker = Parker::new();
+        let io_done_unparker = io_done_parker.unparker().clone();
+        let io_dir = ctx.ubioDir;
+        let callback: CallbackClosure = match io_dir {
+            UbioDir::Read => {
+                let mut result_buffer = result_buffer.clone();
+                Box::new(
+                    move |read_buffer: &Vec<u8>| {
+                        let mut result_buffer = result_buffer.lock().unwrap();
+                        for the_byte in read_buffer {
+                            result_buffer.push(the_byte.clone());
+                        }
+                        io_done_unparker.unpark();
+                    }
+                )
+            },
+            UbioDir::Write => {
+                Box::new(
+                    move |_: &Vec<u8>| {
+                        io_done_unparker.unpark();
+                    }
+                )
+            },
+        };
+
+        let mut bio = Ubio::new(io_dir.clone(), MBR_ADDRESS,
+                                ctx.mem, callback);
+        bio.uBlock = Some(dev);
+
+        IODispatcherSingleton.lock().unwrap().Submit(bio, true /* not used */, false);
+
+        io_done_parker.park(); // block synchronously here until we get "unparked"
+        match io_dir {
+            UbioDir::Read => {
+                Some(result_buffer.lock().unwrap().clone())
+            }
+            UbioDir::Write => {
+                None
+            }
+        }
+    }
+
+    fn _VerifyParity(&self, mem: &Vec<u8>) -> bool {
+        // TODO
+        true
+    }
+
+    fn _VerifySystemUuid(&self, mem: &Vec<u8>) -> bool {
+        // TODO
+        true
+    }
+}
+
+struct DiskIoContext {
+    ubioDir: UbioDir,
+    mem: Vec<u8>,
+}
+
+impl DiskIoContext {
+    pub fn new(ubioDir: UbioDir, mem: Vec<u8>) -> DiskIoContext {
+        DiskIoContext {
+            ubioDir,
+            mem
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::PathBuf;
+    use crate::bio::ubio::{CallbackClosure, Ubio, UbioDir};
+    use crate::device::base::ublock_device::UBlockDevice;
+    use crate::device::device_manager::DeviceManager;
+    use crate::device::ufile::ufile_ssd::UfileSsd;
+    use crate::mbr::mbr_manager::{DiskIoContext, MBR_ADDRESS, MbrManager};
+
+    fn setup() {
+        // set up the logger for the test context
+        env_logger::builder().is_test(true).try_init();
+    }
+
+    #[test]
+    fn test_if_reading_from_MBR_of_a_single_device_works() {
+        setup();
+
+        let test_ufile_ssd = "/tmp/test-ufile-ssd";
+        fs::remove_file(PathBuf::from(test_ufile_ssd));
+
+        // Given: a UBlockDevice with its MBR filled with a specific pattern
+        let PATTERN = vec![0, 2, 4, 6, 1, 3, 5, 7];
+        let empty_callback = Box::new(move |_: &Vec<u8>| {});
+        let mut ubio = Ubio::new(UbioDir::Write, MBR_ADDRESS, PATTERN.clone(), empty_callback);
+        let mut ublock_dev = UfileSsd::new(
+            PathBuf::from(test_ufile_ssd), 100*1024*1024)
+            .boxed();
+        ublock_dev.Open();
+        ublock_dev.SubmitAsyncIO(&mut ubio);
+        let mbr_manager = MbrManager::new();
+        let mut ctx : Vec<Vec<u8>> = Vec::new();
+
+        // When: MBR manager reads MBR from the device
+        mbr_manager._IterateReadFromDevices(ublock_dev, &mut ctx);
+
+        // Then: "ctx" should contain the pattern
+        assert_eq!(1, ctx.len());
+        let mbr = &ctx[0];
+        let expected = PATTERN.to_vec();
+        let actual = mbr[0..PATTERN.len()].to_vec();
+        assert_eq!(expected, actual);
+    }
 }

--- a/src/mbr/mbr_manager.rs
+++ b/src/mbr/mbr_manager.rs
@@ -1,19 +1,18 @@
-use crate::mbr::mbr_info::{ArrayBootRecord, masterBootRecord};
 use std::any::Any;
 use std::rc::Rc;
 use std::sync::Mutex;
-use anyhow::Result;
+
 use crossbeam::sync::Parker;
 use log::warn;
 
 use crate::array::meta::array_meta::ArrayMeta;
 use crate::bio::ubio::{CallbackClosure, Ubio, UbioDir};
-use crate::include::pos_event_id::PosEventId;
-use crate::bio::ubio::{Ubio, UbioDir};
 use crate::device::base::ublock_device::UBlockDevice;
 use crate::event_scheduler::callback::Callback;
 use crate::include::meta_const::CHUNK_SIZE;
+use crate::include::pos_event_id::PosEventId;
 use crate::io_scheduler::io_dispatcher::IODispatcherSingleton;
+use crate::mbr::mbr_info::{ArrayBootRecord, masterBootRecord};
 
 const MBR_CHUNKS : i32 = 1;
 const MBR_ADDRESS: u64 = 0;
@@ -130,6 +129,7 @@ impl DiskIoContext {
 mod tests {
     use std::fs;
     use std::path::PathBuf;
+
     use crate::bio::ubio::{CallbackClosure, Ubio, UbioDir};
     use crate::device::base::ublock_device::UBlockDevice;
     use crate::device::device_manager::DeviceManager;


### PR DESCRIPTION
MbrManager의 _IterateReadFromDevices()와 _DiskIo()를 구현하고 integration test로 기능을 검증. 이 두 fn 은, MBR load/store 코드에 callback 형식으로 결합될 예정.