### PR TITLE
add InitDisk to MBR Manager

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ toml = "0.5.9"
 serde = { version = "1.0", features = ["derive"] }
 strum_macros = "0.24.3"
 crossbeam = "0.8.2"
+bincode = "1.3.3"
 
 [build-dependencies]
 bindgen = "0.60.1"

--- a/src/mbr/mbr_manager.rs
+++ b/src/mbr/mbr_manager.rs
@@ -159,6 +159,7 @@ mod tests {
     use crate::device::base::ublock_device::UBlockDevice;
     use crate::device::device_manager::DeviceManager;
     use crate::device::ufile::ufile_ssd::UfileSsd;
+    use crate::mbr::mbr_info::MBR_VERSION_OFFSET;
     use crate::mbr::mbr_manager::{DiskIoContext, MBR_ADDRESS, MbrManager};
 
     fn setup() {
@@ -217,8 +218,7 @@ mod tests {
 
         // Then: We should be able to see the expected MBR version 123 at byte offset 32 within the UfileSsd
         let mut f = File::open(PathBuf::from(test_ufile_ssd)).unwrap();
-        let mbr_version_pos = 1 /* byte */ * 16 + 4 /* bytes */ * 4;
-        f.seek(SeekFrom::Start(mbr_version_pos));
+        f.seek(SeekFrom::Start(MBR_VERSION_OFFSET as u64));
         let mut buf = [0 as u8; 4];
         let bytes_read = f.read(&mut buf).unwrap();
         assert_eq!(4, bytes_read);


### PR DESCRIPTION
MBR manager의 `systeminfo` 라는 MBR을 disk로 내리는 InitDisk() 부분 채워넣음. integration test 추가.
`bincode` crate의 사용법을 아직 충분히 숙지하지 못해, 일부 MBR struct 는 수동으로 serialize 할 수 밖에 없었음. 이슈 생성 후 추후 해결할 것