### PR TITLE
Add ResetMbr() to MbrManager

### DIFF
--- a/src/mbr/abr_manager.rs
+++ b/src/mbr/abr_manager.rs
@@ -142,7 +142,7 @@ impl AbrManager {
         self.mbrManager.DeleteAbr(name)
     }
 
-    pub fn ResetMbr(&self) -> Result<(), PosEventId> {
+    pub fn ResetMbr(&mut self) -> Result<(), PosEventId> {
         self.mbrManager.ResetMbr()
     }
 

--- a/src/mbr/mbr_manager.rs
+++ b/src/mbr/mbr_manager.rs
@@ -770,7 +770,7 @@ mod tests {
                                         "RAID10".to_string(),
                                         "RAID5".to_string(), unique_id);
         let ret = mbr_manager.CreateAbr(array_meta);
-        ret.unwrap();
+        assert_eq!(0, ret.unwrap());
         assert_eq!(1, mbr_manager.systeminfo.arrayNum);
         assert_eq!(1, mbr_manager.systeminfo.arrayValidFlag[0]);
 


### PR DESCRIPTION
Open PR #30 을 base로 해서 ResetMbr() 만 간단히 추가해본 PR 입니다. 기능 자체는 기존에 구현했던 fn들 활용하면 그리 복잡하지 않았고, 대신 몇가지 리팩토링이 들어갔습니다 1) `mbrBuffer`를 감싼 mutex 제거 (그 대신 `mbrLock` mutex를 잡고 mbrBuffer 접근하도록 함. pos-cpp랑 유사하게 만들기 위해), 2) mbrBuffer 를 self에서 빌려온 다음에 연산을 하는 대신, self에 그대로 두고 연산을 하도록 하기 (전자의 경우 &mut self.mbrBuffer 를 하게 되면 self로 fn 호출시 여러 제약이 걸리는 문제가 있어서...) 3) integration test에서 deviceset 생성하는 부분 반복코드 추출하기 입니다. 감사합니다.
